### PR TITLE
Rename to docker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@
 .Rhistory
 .RData
 .Ruserdata
-2diidockerrunner.Rproj
+docker.Rproj


### PR DESCRIPTION
This pr updates .gitignore to reflect that the new name of this repo is "docker".