### PR TITLE
Fail fast if tag already exists

### DIFF
--- a/pacta/build_with_tag.sh
+++ b/pacta/build_with_tag.sh
@@ -38,6 +38,23 @@ then
     exit 2
 fi
 
+parent="$(dirname $(which $0))"
+if [ "$parent" == "." ]
+then
+    parent="$(pwd)"
+fi
+
+this_repo="$(dirname $parent)"
+existing_tags="$(git -C $this_repo tag)"
+for i in $existing_tags
+do
+    if [ "$i" == "$tag" ]
+    then
+        red "'$tag' already exists in $this_repo."
+        red "Do you need 'git tag --delete $tag'?" && exit 1
+    fi
+done
+
 # Clone
 for repo in $repos
 do
@@ -46,20 +63,19 @@ do
     echo
 done
 
-parent="$(dirname $(which $0))"
-if [ "$parent" == "." ]
-then
-    parent="$(pwd)"
-fi
-
-repos_and_this_repo="$repos $(dirname $parent)"
+repos_and_this_repo="$repos $this_repo"
+echo $repos_and_this_repo
 for repo in $repos_and_this_repo
 do
     if [ -n "$tag" ]
     # Tag
     then
         green "Tagging $(basename $repo) with $tag"
-        git -C "$repo" tag -a "$tag" -m "Release pacta $tag" HEAD || exit 2
+        git -C "$repo" tag -a "$tag" -m "Release pacta $tag" HEAD
+        if [[ "$?" -gt 0 ]]
+        then
+            red "Do you need 'git tag --delete $tag'?" && exit 1
+        fi
         echo
     fi
 


### PR DESCRIPTION
This pr makes the run fail fast if the tag already exists; and it gives instructions about what to do.

This passes the responsability of cleaning up back to the user
instead of adding that complexity in the code.

```bash
➜  pacta git:(3_allow--force) ✗ ./build_with_tag.sh 00
'00' already exists in /home/mauro/git/docker.
Do you need 'git tag --delete 00'?



➜  pacta git:(3_allow--force) ✗ git tag --delete 00
Deleted tag '00' (was c98684c)

➜  pacta git:(3_allow--force) ✗ ./build_with_tag.sh 00
Cloning into 'PACTA_analysis'...
remote: Enumerating objects: 129, done.
remote: Counting objects: 100% (129/129), done.
remote: Compressing objects: 100% (115/115), done.
remote: Total 129 (delta 10), reused 70 (delta 7), pack-reused 0
Receiving objects: 100% (129/129), 2.04 MiB | 2.73 MiB/s, done.
Resolving deltas: 100% (10/10), done.

# ... more output
```

(Sorry that the name of the branch does not reflect what I finally did. I originally thought I would implement `--force` but I changed my mind; this approach seems safer and more lean.)