### PR TITLE
Clone and build into a temporary directory

### DIFF
--- a/pacta/build_with_tag.sh
+++ b/pacta/build_with_tag.sh
@@ -23,6 +23,15 @@ green () {
     printf "\033[32m${1}\033[0m\n"
 }
 
+dir_start="$(pwd)"
+dir_temp="$(mktemp -d)"
+cleanup () {
+  green "The pacta repositories were cloned into: $dir_temp'"
+  green "You may cleanup with 'rm -rf $dir_temp'"
+  cd $dir_start
+}
+trap cleanup EXIT
+
 user_results="user_results"
 url="git@github.com:2DegreesInvesting/"
 tag="$1"
@@ -38,7 +47,12 @@ then
     exit 2
 fi
 
-# Clone
+
+
+
+
+
+cd $dir_temp
 for repo in $repos
 do
     remote="${url}${repo}.git"
@@ -46,41 +60,43 @@ do
     echo
 done
 
+# Tag and log
+for repo in $repos
+do
+    green "Tagging $(basename $repo) with $tag"
+    git -C "$repo" tag -a "$tag" -m "Release pacta $tag" HEAD || exit 2
+    echo
+
+    green "$(git -C $repo log --pretty='%h %d <%an> (%cr)' | head -n 1)"
+    echo
+done
+
+# Copy Dockerfile alongside pacta siblings and build the image
+cp "${dir_start}/Dockerfile" "$dir_temp"
+docker build --tag 2dii_pacta:"$tag" --tag 2dii_pacta:latest .
+echo
+
+cd $dir_start
+
+
+
+
+
+
 parent="$(dirname $(which $0))"
 if [ "$parent" == "." ]
 then
     parent="$(pwd)"
 fi
+this_repo="$(dirname $parent)"
 
-repos_and_this_repo="$repos $(dirname $parent)"
-for repo in $repos_and_this_repo
-do
-    if [ -n "$tag" ]
-    # Tag
-    then
-        green "Tagging $(basename $repo) with $tag"
-        git -C "$repo" tag -a "$tag" -m "Release pacta $tag" HEAD || exit 2
-        echo
-    fi
-
-    # Log
-    green "$(git -C $repo log --pretty='%h %d <%an> (%cr)' | head -n 1)"
-    echo
-done
-
-docker rmi --force $(docker images -q '2dii_pacta' | uniq)
+# Tag and log
+green "Tagging $(basename $this_repo) with $tag"
+echo
+green "$(git log --pretty='%h %d <%an> (%cr)' | head -n 1)"
 echo
 
-parent="$(dirname $(which $0))"
-docker build --tag 2dii_pacta:"$tag" --tag 2dii_pacta:latest "$parent"
-echo
-
-for repo in $repos
-do
-    rm -rf "$repo"
-done
-
-image_tar_gz="${parent}/2dii_pacta.tar.gz"
+image_tar_gz="2dii_pacta.tar.gz"
 green "Saving 2dii_pacta into $image_tar_gz ..."
 docker save 2dii_pacta | gzip -q > "$image_tar_gz"
 echo

--- a/pacta/build_with_tag.sh
+++ b/pacta/build_with_tag.sh
@@ -83,15 +83,9 @@ cd $dir_start
 
 
 
-parent="$(dirname $(which $0))"
-if [ "$parent" == "." ]
-then
-    parent="$(pwd)"
-fi
-this_repo="$(dirname $parent)"
-
 # Tag and log
-green "Tagging $(basename $this_repo) with $tag"
+green "Tagging $(basename $(pwd)) with $tag"
+git tag -a "$tag" -m "Release pacta $tag" HEAD || exit 2
 echo
 green "$(git log --pretty='%h %d <%an> (%cr)' | head -n 1)"
 echo


### PR DESCRIPTION
Closes #4 

This PR clones pacta siblings and builds the image in a temporary directory. The output stays in the working directory.

Note that the temporary directory is not removed. Cleaning up is up to the user, and they get instructions about how to cleanup.

--

This has many changes and it's hard to understand precisely what changed. It should be either seen as a new file or I'm happy to try break it down into smaller steps. It didn't come out that way, unfortunately, because I developed it in a quite experimental way. Because of this too many changes, I changed #7, #8, and #9 to a draft. That is to minimize merge conflicts. Once we decide if and how to review this pr, I'm happy to adapt the other ones -- but this one seems more useful so I give priority to it.
