### PR TITLE
Fail fast with existing docker images matching 2dii_pacta

### DIFF
--- a/pacta/build_with_tag.sh
+++ b/pacta/build_with_tag.sh
@@ -47,10 +47,11 @@ then
     exit 2
 fi
 
-
-
-
-
+existing_images="$(docker images -q '2dii_pacta')"
+if [ -n "$existing_images" ]
+then
+    red "Please remove existing docker images matching '2dii_pacta'." && exit 1
+fi
 
 cd $dir_temp
 for repo in $repos


### PR DESCRIPTION
Closes #6 
 
This PR makes the code fail fast if there is one or more images matching 2dii_pacta. It's up to the user to cleanup.