### PR TITLE
Exit if docker errors

### DIFF
--- a/pacta/build_with_tag.sh
+++ b/pacta/build_with_tag.sh
@@ -54,7 +54,7 @@ do
     fi
 done
 
-existing_images="$(docker images -q '2dii_pacta')"
+existing_images="$(docker images -q '2dii_pacta' || exit 1)"
 if [ -n "$existing_images" ]
 then
     red "Existing docker images match '2dii_pacta':"

--- a/pacta/build_with_tag.sh
+++ b/pacta/build_with_tag.sh
@@ -54,6 +54,11 @@ do
     fi
 done
 
+if (! docker images > /dev/null 2>&1 )
+then
+  red "The docker daemon does not appear to be running." && exit 1
+fi
+
 existing_images="$(docker images -q '2dii_pacta' || exit 1)"
 if [ -n "$existing_images" ]
 then


### PR DESCRIPTION
Closes #23 

I added an explicit instruction to exit if the first docker
command exits with status > 0. But I don't know how to
simulate the docker deamon is not running. Stopping it
seems uncomon and I fear I may not be able to bring it
back to life promptly. 

If you can reproduce the state where the docker deamon
is not running, please try this PR and let me konw
if it worked.

In the case when the docker deamon is running, this PR
seems to show the expected behaviour (completing the
task).﻿
