### PR TITLE
Expand '.' to the more informative top level name

### DIFF
--- a/pacta/build_with_tag.sh
+++ b/pacta/build_with_tag.sh
@@ -49,8 +49,9 @@ for i in $existing_tags
 do
     if [ "$i" == "$tag" ]
     then
-        red "'$tag' already exists in $this_repo."
-        red "You may delete it with: git tag --delete $tag" && exit 1
+        toplevel="$(basename $(git rev-parse --show-toplevel))"
+        red "Tag '$tag' already exists in the repository $toplevel/."
+        red "You may delete it with: git tag --delete $tag." && exit 1
     fi
 done
 

--- a/pacta/build_with_tag.sh
+++ b/pacta/build_with_tag.sh
@@ -50,7 +50,7 @@ do
     if [ "$i" == "$tag" ]
     then
         toplevel="$(basename $(git rev-parse --show-toplevel))"
-        red "Tag '$tag' already exists in the repository $toplevel/."
+        red "Tag '$tag' already exists in the repository $toplevel."
         red "You may delete it with: git tag --delete $tag." && exit 1
     fi
 done


### PR DESCRIPTION
Fixes #15

This PR produces a more informative message when the given tag
already exists in the repo. 

Thanks @cjyetman﻿
