### PR TITLE
Remove needless variable user_results

### DIFF
--- a/pacta/README.md
+++ b/pacta/README.md
@@ -100,21 +100,17 @@ The docker image can then be used as intended with a script such as...
 ``` {.bash}
 portfolio_name="TestPortfolio"
 working_dir="$(pwd)"/working_dir
-user_results="$(pwd)"/user_results
 
 docker run --rm -ti \
   --network none \
   --user 1000:1000 \
   --memory="4g" \
   --mount type=bind,source="$working_dir",target=/bound/working_dir \
-  --mount type=bind,source="$user_results",target=/user_results \
+  --mount type=bind \
   2dii_pacta \
   /bound/bin/run-r-scripts "$portfolio_name"
 ```
 
-where you set `working_dir` to the path to the directory that contains
-the user specific portfolio info on the server, and you set
-`user_results` to the path to the directory that contains the survey
-(and other) results that are relevant to the specific user on the
-server. Those directories will then be mounted inside of the docker
-container in the appropriate locations.
+where you set `working_dir` to the path to the directory that contains the user
+specific portfolio info on the server. That directory will then be mounted
+inside of the docker container in the appropriate location.

--- a/pacta/README.md
+++ b/pacta/README.md
@@ -100,17 +100,21 @@ The docker image can then be used as intended with a script such as...
 ``` {.bash}
 portfolio_name="TestPortfolio"
 working_dir="$(pwd)"/working_dir
+user_results="$(pwd)"/user_results
 
 docker run --rm -ti \
   --network none \
   --user 1000:1000 \
   --memory="4g" \
   --mount type=bind,source="$working_dir",target=/bound/working_dir \
-  --mount type=bind \
+  --mount type=bind,source="$user_results",target=/user_results \
   2dii_pacta \
   /bound/bin/run-r-scripts "$portfolio_name"
 ```
 
-where you set `working_dir` to the path to the directory that contains the user
-specific portfolio info on the server. That directory will then be mounted
-inside of the docker container in the appropriate location.
+where you set `working_dir` to the path to the directory that contains
+the user specific portfolio info on the server, and you set
+`user_results` to the path to the directory that contains the survey
+(and other) results that are relevant to the specific user on the
+server. Those directories will then be mounted inside of the docker
+container in the appropriate locations.

--- a/pacta/build_with_tag.sh
+++ b/pacta/build_with_tag.sh
@@ -29,7 +29,6 @@ cleanup () {
 }
 trap cleanup EXIT
 
-user_results="user_results"
 url="git@github.com:2DegreesInvesting/"
 tag="$1"
 repos="${@:2}"


### PR DESCRIPTION
Closes #30

Remove the variable `user_resulst` and all references to it. It
is used nowhere.

Thanks @cjyetman﻿

I did not run the program to test it. But I'm pretty confident the
behavior won't change because the variable was used nowhere.
