### PR TITLE
Fail fast if tag is unavailable on remotes

### DIFF
--- a/pacta/build_with_tag.sh
+++ b/pacta/build_with_tag.sh
@@ -43,14 +43,21 @@ then
     exit 2
 fi
 
-existing_tags="$(git tag)"
-for i in $existing_tags
+remotes="$(echo $repos | tr ' ' ',')"
+remotes=$(eval "echo $url{$remotes}.git")
+tags=""
+for i in $remotes
+do
+    tags_i="$(git ls-remote --tags --ref $i | cut -d / -f 3)"
+    tags="$tags $tags_i"
+done
+tags="$(echo $tags | tr ' ' '\n' | sort -V | uniq)"
+for i in $tags
 do
     if [ "$i" == "$tag" ]
     then
-        toplevel="$(basename $(git rev-parse --show-toplevel))"
-        red "Tag '$tag' already exists in the repository $toplevel."
-        red "You may delete it with: git tag --delete $tag." && exit 1
+        red "Tag '$tag' is taken. Choose a new tag different from these ones:"
+        red "$(echo $tags | tr ' ' '\n' | sort -V | uniq)" && exit 1
     fi
 done
 


### PR DESCRIPTION
Closes #14﻿

![image](https://user-images.githubusercontent.com/5856545/106189829-6b559600-616e-11eb-9e6d-87c3d6a6b49c.png)

This PR addresses "it should check what tags already exist in each of the repos (including itself/the docker repo), and then determine if the specified tag is available (i.e not already used in any of the repos)".

It does not address "and valid/reasonable (i.e. greater than any of the existing tags in any of the repos)".
