### PR TITLE
Warn unset ssh keys

### DIFF
--- a/pacta/build_with_tag.sh
+++ b/pacta/build_with_tag.sh
@@ -16,6 +16,10 @@ red () {
     printf "\033[31m${1}\033[0m\n"
 }
 
+yellow () {
+    printf "\033[33m${1}\033[0m\n"
+}
+
 green () {
     printf "\033[32m${1}\033[0m\n"
 }
@@ -60,6 +64,12 @@ do
         red "$(echo $tags | tr ' ' '\n' | sort -V | uniq)" && exit 1
     fi
 done
+if [ -z "$tags" ]
+then
+    yellow "These remotes returned no tag:"
+    yellow "$(echo $remotes | tr ' ' '\n')"
+    yellow "Are your SSH keys unset?"
+fi
 
 if (! docker images > /dev/null 2>&1 )
 then


### PR DESCRIPTION
Closes #39 
Relates to #41, which could replace or complement this PR.

This PR warns if remote repos return no tags with a hint that 
ssh keys may be unset.

It adds the new `yellow` command suitable for warnings.

For example, this is after I deleted ~/.ssh:

![image](https://user-images.githubusercontent.com/5856545/106338710-1ee78480-625a-11eb-882f-35f983e14790.png)

﻿
