### PR TITLE
Fail fast if ssh keys are unset

### DIFF
--- a/pacta/build_with_tag.sh
+++ b/pacta/build_with_tag.sh
@@ -30,6 +30,8 @@ cleanup () {
 trap cleanup EXIT
 
 url="git@github.com:2DegreesInvesting/"
+[ ! -d ~/.ssh ] && red "SSH keys are unset" && exit 1
+
 tag="$1"
 repos="${@:2}"
 if [ -z "$repos" ]


### PR DESCRIPTION
Closes #39 
Relates to #40, which could replace or complement this PR.

This PR make the script exit with an informative message when
SSH keys are unset. Later we may add support for https but I
found this less straightforward than I hoped and I'm not sure it's
worth the effort right now.

For example, this is what happens if I delete ~/.ssh:

![image](https://user-images.githubusercontent.com/5856545/106338800-59512180-625a-11eb-98c5-bc757f0d5d1c.png)

