### PR TITLE
add local docker git tags to the list

### DIFF
--- a/pacta/build_with_tag.sh
+++ b/pacta/build_with_tag.sh
@@ -55,6 +55,11 @@ do
     tags_i="$(git ls-remote --tags --ref $i | cut -d / -f 3)"
     tags="$tags $tags_i"
 done
+
+# add tags from the current local docker git repo
+tags_i="$(git tag)"
+tags="$tags $tags_i"
+
 tags="$(echo $tags | tr ' ' '\n' | sort -V | uniq)"
 for i in $tags
 do


### PR DESCRIPTION
closes #45 

This should add the git tags found in the local docker git repo to the list of the remote repo tags which are later checked against the specified tag (in the command's arguments) to make sure there isn't a conflict, which makes sense because before we were simply ignoring the local docker repo and only checking the tags in the remote repos.