### PR TITLE
add SSH to GitHub check and a note about it in the README

### DIFF
--- a/pacta/README.md
+++ b/pacta/README.md
@@ -20,6 +20,8 @@ the image.
 
 # Usage
 
+You must have SSH authentication to your GitHub account setup to use this tool.
+
 Before running the script, you will need to remove any existing
 2dii_pacta docker images that are loaded. You can do that, for instance,
 with `docker rmi --force $(docker images -q '2dii_pacta' | uniq)`.

--- a/pacta/build_with_tag.sh
+++ b/pacta/build_with_tag.sh
@@ -47,6 +47,12 @@ then
     exit 2
 fi
 
+ssh -T git@github.com
+if [ $? -ne 1 ];
+then
+  red "You must have SSH authentication to GitHub setup properly to use this tool." && exit 1
+fi
+
 remotes="$(echo $repos | tr ' ' ',')"
 remotes=$(eval "echo $url{$remotes}.git")
 tags=""


### PR DESCRIPTION
closes #43

According to [GitHub docs](https://docs.github.com/en/github/authenticating-to-github/testing-your-ssh-connection), `ssh -T git@github.com` seems to be the proper way to test if the current user is able to connect to GitHub using SSH authentication, which at the moment is a requirement for this script to work. After some experimentation, I determined that `ssh -T git@github.com` will return `1` if it's successful, and probably some other positive integer if it is not.

Based on that, I added a test early on in the script to fail early with a message if the current user cannot connect to GitHub with SSH, and I also added a note to the README that SSH is necessary to use this tool.