### PR TITLE
remove the temp dir when cleaning up

### DIFF
--- a/pacta/build_with_tag.sh
+++ b/pacta/build_with_tag.sh
@@ -27,8 +27,7 @@ green () {
 dir_start="$(pwd)"
 dir_temp="$(mktemp -d)"
 cleanup () {
-  green "A temporary directory was created at: $dir_temp"
-  green "You may remove it with: rm -rf $dir_temp"
+  rm -rf $dir_temp
   cd $dir_start
 }
 trap cleanup EXIT


### PR DESCRIPTION
rather than only giving a message... can't see any reason why a user would want to keep the temp dir around, so this seems better to properly clean up rather than leaving it up to the user to see this message, understand it, and go out of their way to implement it somewhere else

closes #22