### PR TITLE
point to new stress test repos

### DIFF
--- a/pacta/Dockerfile
+++ b/pacta/Dockerfile
@@ -4,12 +4,14 @@ LABEL maintainer='Mauro Lepore'
 COPY PACTA_analysis /bound
 COPY create_interactive_report /create_interactive_report
 COPY pacta-data /pacta-data
-COPY StressTestingModelDev /StressTestingModelDev
+COPY r2dii.climate.stress.test /r2dii.climate.stress.test
+COPY r2dii.stress.test.data /r2dii.stress.test.data
 
 RUN chmod -R a+rwX /bound
 RUN chmod -R a+rwX /create_interactive_report
 RUN chmod -R a+rwX /pacta-data
-RUN chmod -R a+rwX /StressTestingModelDev
+RUN chmod -R a+rwX /r2dii.climate.stress.test
+RUN chmod -R a+rwX /r2dii.stress.test.data
 
 RUN echo "options(tinytex.tlmgr.path = '/root/.TinyTeX/bin/x86_64-linux/tlmgr')" > .Rprofile
 RUN chmod -R a+rwX /root

--- a/pacta/README.md
+++ b/pacta/README.md
@@ -34,7 +34,8 @@ and friends repos. You can see existing tags in the relevant repos
 here:\
 <https://github.com/2DegreesInvesting/PACTA_analysis/tags>\
 <https://github.com/2DegreesInvesting/create_interactive_report/tags>\
-<https://github.com/2DegreesInvesting/StressTestingModelDev/tags>\
+<https://github.com/2DegreesInvesting/r2dii.climate.stress.test/tags>\
+<https://github.com/2DegreesInvesting/r2dii.stress.test.data/tags>\
 <https://github.com/2DegreesInvesting/pacta-data/tags>\
 <https://github.com/2DegreesInvesting/docker/tags>
 

--- a/pacta/build_with_tag.sh
+++ b/pacta/build_with_tag.sh
@@ -5,7 +5,7 @@
 # build_with_tag 0.0.0.999
 #
 # # Optionally give the names of the repos as trailing arguments
-# build_with_tag 0.0.0.999 PACTA_analysis StressTestingModelDev
+# build_with_tag 0.0.0.999 PACTA_analysis r2dii.climate.stress.test
 #
 # # With the help of pacta-find, you don't need to know the names
 # # of pacta siblings -- it's enough to know the path to the parent.
@@ -37,7 +37,7 @@ tag="$1"
 repos="${@:2}"
 if [ -z "$repos" ]
 then
-    repos="PACTA_analysis create_interactive_report StressTestingModelDev pacta-data"
+    repos="PACTA_analysis create_interactive_report r2dii.climate.stress.test r2dii.stress.test.data pacta-data"
 fi
 
 if [ -z "$tag" ]


### PR DESCRIPTION
changes to the Docker creation process and documentation to work with the new stress test repos

depends on https://github.com/2DegreesInvesting/PACTA_analysis/pull/469